### PR TITLE
Drastic cleanup of Newsflow stuffs

### DIFF
--- a/web/concrete/blocks/dashboard_newsflow_latest/controller.php
+++ b/web/concrete/blocks/dashboard_newsflow_latest/controller.php
@@ -4,6 +4,11 @@ use Loader;
 use \Concrete\Core\Block\BlockController;
 use \Concrete\Core\Activity\Newsflow;
 
+/**
+ * @property mixed $slot
+ * Class Controller
+ * @package Concrete\Block\DashboardNewsflowLatest
+ */
 class Controller extends BlockController {
 
 	protected $btCacheBlockRecord = true;
@@ -21,16 +26,16 @@ class Controller extends BlockController {
 	public function getBlockTypeName() {
 		return t("Dashboard Newsflow Latest");
 	}
-	
-	public function view() {
+
+    public function view() {
 		// get the latest data as well
-		$slots = Newsflow::getSlotContents();
+		$slots = Newsflow::getInstance()->getSlotContents();
 		$this->set('slot', $slots[$this->slot]);
 		
 		// this is kind of a hack
 		if ($this->slot == 'C') { 
-			$ni = Newsflow::getEditionByPath('/newsflow');
-			if (is_object($ni)) { 
+			$ni = Newsflow::getInstance()->getEditionByPath('/newsflow');
+			if ($ni !== false) {
 				$this->set('editionTitle', $ni->getTitle());
 				$this->set('editionDescription', $ni->getDescription());
 				$this->set('editionDate', $ni->getDate());

--- a/web/concrete/core/Activity/Newsflow.php
+++ b/web/concrete/core/Activity/Newsflow.php
@@ -1,73 +1,128 @@
 <?
 namespace Concrete\Core\Activity;
-use Loader;
+
 use Config;
 use Package;
 use Environment;
 use Marketplace;
-class Newsflow {
-	
-	const E_NEWSFLOW_SUPPORT_MANUALLY_DISABLED = 21;
+use Concrete\Core\File\Service\File;
 
-	protected $isConnected = false;
-	protected $connectionError = false;
-	static $slots;
-	
-	
-	public static function getInstance() {
-		static $instance;
-		if (!isset($instance)) {
-			$m = __CLASS__;
-			$instance = new $m;
-		}
-		return $instance;
-	}
-	
-	public function __construct() {
-		if (defined('ENABLE_APP_NEWS') && ENABLE_APP_NEWS == false) {
-			$this->connectionError = Newsflow::E_NEWSFLOW_SUPPORT_MANUALLY_DISABLED;
-			return;
-		}
-	}
-	
-	public function hasConnectionError() {
-		return $this->connectionError != false;
-	}
-	
-	public function getConnectionError() {
-		return $this->connectionError;
-	}
-	
-	public static function getEditionByID($cID) {
-		$ni = self::getInstance();
-		if (!$ni->hasConnectionError()) {
-			$fh = Loader::helper('file');
-			$cfToken = Marketplace::getSiteToken();
-			$r = $fh->getContents(NEWSFLOW_URL . '/' . DISPATCHER_FILENAME . '/?_ccm_view_external=1&cID=' . $cID . '&cfToken=' . $cfToken);
-			$obj = NewsflowItem::parseResponse($r);
-			return $obj;			
-		}
-	}
-	
-	public static function getEditionByPath($cPath) {
-		$ni = self::getInstance();
-		$cPath = trim($cPath, '/');
-		if (!$ni->hasConnectionError()) {
-			$fh = Loader::helper('file');
-			$cfToken = Marketplace::getSiteToken();
-			$r = $fh->getContents(NEWSFLOW_URL . '/' . DISPATCHER_FILENAME . '/' . $cPath . '/-/view_external?cfToken=' . $cfToken);
-			$obj = NewsflowItem::parseResponse($r);
-			return $obj;			
-		}
-	}
-	
-	public static function getSlotContents() {
-		if (!isset(self::$slots)) {
-			$fh = Loader::helper('file');
-			$cfToken = Marketplace::getSiteToken();
-			$r = $fh->getContents(NEWSFLOW_SLOT_CONTENT_URL . '?cfToken=' . $cfToken);
-			self::$slots = NewsflowSlotItem::parseResponse($r);
-		}
-		return self::$slots;
-	}
+/**
+ * Class Newsflow
+ *
+ * A class used for retrieving the latest news and updates from Concrete5. This is a singleton class that should be
+ * instantiated via Newsflow::getInstance(). This object is prevented from being created if the config file has the
+ * ENABLE_APP_NEWS setting set to false.
+ * @package Concrete\Core\Activity
+ */
+class Newsflow
+{
+
+    const E_NEWSFLOW_SUPPORT_MANUALLY_DISABLED = 21;
+
+    protected $isConnected = false;
+    protected $connectionError = false;
+    protected $slots = null;
+
+    /**
+     * @return self Returns a singleton for this class
+     */
+    public static function getInstance()
+    {
+        static $instance = null;
+        if ($instance === null) {
+            $m = __CLASS__;
+            $instance = new $m;
+        }
+        return $instance;
+    }
+
+    /**
+     * protected constructor to prevent instances other than the singleton
+     */
+    protected function __construct()
+    {
+        if (defined('ENABLE_APP_NEWS') && ENABLE_APP_NEWS == false) {
+            $this->connectionError = Newsflow::E_NEWSFLOW_SUPPORT_MANUALLY_DISABLED;
+            return;
+        }
+    }
+
+    /**
+     * protected clone function to prevent instances other than the singleton
+     */
+    protected function __clone()
+    {
+        //we don't want clones of our singleton running around
+    }
+
+    /**
+     * @return bool Returns true if there is a connection error, false if there is no error.
+     */
+    public function hasConnectionError()
+    {
+        return $this->connectionError !== false;
+    }
+
+    /**
+     * @return bool|int Returns false if there are no errors, or an int corresponding to one of the E_* class constants
+     */
+    public function getConnectionError()
+    {
+        return $this->connectionError;
+    }
+
+    /**
+     * Retrieves a NewsflowItem object for a given collection ID
+     * @param int $cID
+     * @return bool|NewsflowItem Returns a NewsflowItem object, false if there was an error or one could not be located.
+     */
+    public function getEditionByID($cID)
+    {
+        if (!$this->hasConnectionError()) {
+            $fileService = new File();
+            $cfToken = Marketplace::getSiteToken();
+            $path = NEWSFLOW_URL . '/' . DISPATCHER_FILENAME . '/?_ccm_view_external=1&cID=' . rawurlencode($cID) . '&cfToken=' . rawurlencode($cfToken);
+            $response = $fileService->getContents($path);
+            $obj = NewsflowItem::parseResponse($response);
+            return $obj;
+        }
+        return false;
+    }
+
+    /**
+     * Retrieves a NewsflowItem object for a given collection path
+     * @param $cPath
+     * @return bool|NewsflowItem
+     */
+    public function getEditionByPath($cPath)
+    {
+        $ni = self::getInstance();
+        $cPath = trim($cPath, '/');
+        if (!$ni->hasConnectionError()) {
+            $fileService = new File();
+            $cfToken = Marketplace::getSiteToken();
+            $path = NEWSFLOW_URL . '/' . DISPATCHER_FILENAME . '/' . $cPath . '/-/view_external?cfToken=' . rawurlencode($cfToken);
+            $response = $fileService->getContents($path);
+            $obj = NewsflowItem::parseResponse($response);
+            return $obj;
+        }
+        return false;
+    }
+
+    /**
+     * Retrieves an array of NewsflowSlotItems
+     * @return NewsflowSlotItem[]|null
+     */
+    public function getSlotContents()
+    {
+        if ($this->slots === null) {
+            $fileService = new File();
+            $cfToken = Marketplace::getSiteToken();
+            $path = NEWSFLOW_SLOT_CONTENT_URL . '?cfToken=' . rawurlencode($cfToken);
+            $response = $fileService->getContents($path);
+            $this->slots = NewsflowSlotItem::parseResponse($response);
+        }
+        return $this->slots;
+    }
 }

--- a/web/concrete/core/Activity/NewsflowItem.php
+++ b/web/concrete/core/Activity/NewsflowItem.php
@@ -1,32 +1,112 @@
 <?
-
 namespace Concrete\Core\Activity;
-use Loader;
-class NewsflowItem {
-	
-	public function getID() {return $this->id;}
-	public function getTitle() {return $this->title;}
-	public function getContent() {return $this->content;}
-	public function getDate() {return $this->date;}
-	public function getDescription() {return $this->description;}
-	
-	public static function parseResponse($r) {
-		try {
-			// Parse the returned XML file
-			$obj = @Loader::helper('json')->decode($r);
-			if (is_object($obj)) {
-				$mi = new NewsflowItem();
-				$mi->title = $obj->title;
-				$mi->content = $obj->content;
-				$mi->id = $obj->id;
-				$mi->description = $obj->description;
-				$mi->date = $obj->date;
-				return $mi;
-			}
-		} catch (Exception $e) {
-			throw new Exception(t('Unable to parse news response.'));
-		}
 
+use Concrete\Core\Http\Service\Json;
+
+/**
+ * Class NewsflowItem
+ * @package Concrete\Core\Activity
+ */
+class NewsflowItem {
+
+    protected $id;
+    protected $title;
+    protected $content;
+    protected $date;
+    protected $description;
+
+    /**
+     * @return int
+     */
+    public function getID()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContent()
+    {
+        return $this->content;
+    }
+
+    /**
+     * todo: determine return type
+     * @return mixed
+     */
+    public function getDate()
+    {
+        return $this->date;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * @param int $id
+     * @param string $title
+     * @param string $content
+     * @param mixed $date todo: needs type fixed
+     * @param string $description
+     */
+    public function __construct($id, $title, $content, $date, $description)
+    {
+        $this->id = $id;
+        $this->title = $title;
+        $this->content = $content;
+        $this->date = $date;
+        $this->description = $description;
+    }
+
+    /**
+     * @param string $response A JSON encoded array. Expected format of:
+     * <code>
+     * {
+     *  'id': value,
+     *  'title': value,
+     *  'content': value,
+     *  'date': value,
+     *  'description': value
+     * }
+     * </code>
+     * @return NewsflowItem Returns the NewsflowItem if one could be created from the response, otherwise throws an exception
+     * @throws \Exception
+     */
+    public static function parseResponse($response)
+    {
+		try {
+            $json = new Json();
+            $obj = $json->decode($response);
+            if (is_object($obj) && isset($obj->id) && isset($obj->title) && isset($obj->content)
+                && isset($obj->date) && isset($obj->description)
+            ) {
+                return new NewsflowItem(
+                    $obj->id,
+                    $obj->title,
+                    $obj->content,
+                    $obj->date,
+                    $obj->description
+                );
+            } else {
+                throw new \Exception(t('Unable to parse news response.'));
+            }
+        } catch (\Exception $e) {
+            throw new \Exception(t('Unable to parse news response.'));
+		}
 	}
 	
 }

--- a/web/concrete/core/Activity/NewsflowSlotItem.php
+++ b/web/concrete/core/Activity/NewsflowSlotItem.php
@@ -1,19 +1,46 @@
 <?
 namespace Concrete\Core\Activity;
-use Loader;
+
+use Concrete\Core\Http\Service\Json;
+
 class NewsflowSlotItem {
 	
 	protected $content;
-	public function __construct($content) {
+
+    /**
+     * @param $content
+     */
+    public function __construct($content)
+    {
 		$this->content = $content;
 	}
-	public function getContent() {return $this->content;}
 
-	public static function parseResponse($r) {
+    /**
+     * @return mixed
+     */
+    public function getContent()
+    {
+        return $this->content;
+    }
+
+    /**
+     * @param string $response Parses a JSON response that looks similar to below
+     * <code>
+     * {
+     *     'slots': {
+     *          'slotKey1': 'content',
+     *          'slotKey2': 'other content',
+     *          ...
+     *      }
+     * }
+     * </code>
+     * @return NewsflowSlotItem[] Returns an associative array of NewsflowSlotItems
+     */
+    public static function parseResponse($response) {
 		$slots = array();
 		try {
-			// Parse the returned XML file
-			$obj = @Loader::helper('json')->decode($r);
+            $json = new Json();
+            $obj = $json->decode($response);
 			if (is_object($obj)) {
 				if (is_object($obj->slots)) {
 					foreach($obj->slots as $key => $content) {
@@ -22,7 +49,8 @@ class NewsflowSlotItem {
 					}
 				}
 			}
-		} catch (Exception $e) {}
+        } catch (\Exception $e) {
+        }
 		return $slots;
 
 	}

--- a/web/concrete/tools/newsflow.php
+++ b/web/concrete/tools/newsflow.php
@@ -1,13 +1,14 @@
 <?
 defined('C5_EXECUTE') or die("Access Denied.");
+
 if (Loader::helper('validation/numbers')->integer($_REQUEST['cID'])) {
-	$ed = Newsflow::getEditionByID($_REQUEST['cID']);
-	if (is_object($ed)) {
+	$ed = Newsflow::getInstance()->getEditionByID($_REQUEST['cID']);
+	if ($ed !== false) {
 		print $ed->getContent();
 	}
 } else if (isset($_REQUEST['cPath'])) {
-	$ed = Newsflow::getEditionByPath($_REQUEST['cPath']);
-	if (is_object($ed)) {
+	$ed = Newsflow::getInstance()->getEditionByPath($_REQUEST['cPath']);
+	if ($ed !== false) {
 		print $ed->getContent();
 	}
 }


### PR DESCRIPTION
Tabs to Spaces
Removed ability to instantiate Newflow class outside of the singleton
Changed methods to always have a return type or throw an exception
Fixed Exception namespacing
Removed references to deprecated Loader class
PHPDocs
Changed Static functions to no longer be static in many places, now requiring the singleton to be called, in order to access what were previously static functions
Added properties to classes for IDE help
Changed path's to use rawurlencode in appropriate locations
