### PR TITLE
Attribute Controller Cleanup

### DIFF
--- a/web/concrete/core/Form/Service/Validation.php
+++ b/web/concrete/core/Form/Service/Validation.php
@@ -225,7 +225,7 @@ use Loader;
 		 *         $e = $val->getError();
 		 *     }
 		 * </code>
-		 * @return ValidationErrorHelper
+		 * @return \Concrete\Core\Error\Error
 		 */
 		public function getError() {
 			return $this->error;


### PR DESCRIPTION
Added properties that weren't explicitly defined as protected properties (this seemed ok based on my code searches and quick testing). And added PHPDocs for these to help with code completion

Started getting rid of the helper methods in favor of the namespaced class needed

Changed handle regex to use the string validation method that already existed

Tweaked PHPDoc return type on the form validation service
